### PR TITLE
Fix compatibility of Login Handler with IPS 4.3

### DIFF
--- a/dev/setup/install.php
+++ b/dev/setup/install.php
@@ -39,17 +39,17 @@ class ips_plugins_setup_install
 		$doesNotExist = false;
 
 		try {
-			\IPS\Db::i()->select('login_key', 'core_login_handlers', array('login_key=?', 'steam'))->first();
+			\IPS\Db::i()->select('login_classname', 'core_login_methods', array('login_classname=?', 'IPS\Login\Steam'))->first();
 		} catch (UnderflowException $e) {
 			$doesNotExist = true;
 		}
 
 		if ($doesNotExist) {
-			$maxLoginOrder = \IPS\Db::i()->select('MAX(login_order)', 'core_login_handlers')->first();
+			$maxLoginOrder = \IPS\Db::i()->select('MAX(login_order)', 'core_login_methods')->first();
 
-			\IPS\Db::i()->insert('core_login_handlers', array(
+			\IPS\Db::i()->insert('core_login_methods', array(
 				'login_settings' => '{"steam_apikey":"","use_steam_name":true}',
-				'login_key' => 'Steam',
+				'login_classname' => 'IPS\Login\Steam',
 				'login_enabled' => 1,
 				'login_order' => $maxLoginOrder + 1,
 				'login_acp' => 0

--- a/upload/system/Login/Steam.php
+++ b/upload/system/Login/Steam.php
@@ -257,7 +257,13 @@ class _Steam extends \IPS\Login\LoginAbstract
 	 */
 	private function get($param)
 	{
-		return str_replace(' ', '+', trim(urldecode(\IPS\Request::i()->{$param})));
+		$value = isset($_GET[$param]) ? $_GET[$param] : null;
+
+		if ($value === null) {
+			return null;
+		}
+
+		return trim(urldecode($value));
 	}
 
 	/**

--- a/upload/system/Login/Steam.php
+++ b/upload/system/Login/Steam.php
@@ -24,6 +24,16 @@ class _Steam extends \IPS\Login\LoginAbstract
 	public static $icon = 'steam';
 
 	/**
+	 * Get title
+	 *
+	 * @return	string
+	 */
+	public static function getTitle()
+	{
+		return 'Steam';
+	}
+
+	/**
 	 * Get Form
 	 *
 	 * @param    string $url The URL for the login page


### PR DESCRIPTION
Fixes #110 #108 #107 #106 and #87 

API key/method settings will probably need to be readded unless the 4.3 update merged those or someone else wants to add a merge script too.

